### PR TITLE
Fix missing quote in default.hbs

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <link rel="stylesheet" type="text/css" href="{{asset "css/normalize.css"}}" />
-    <link rel="stylesheet" type="text/css" href="{{asset css/screen.css"}}" />
+    <link rel="stylesheet" type="text/css" href="{{asset "css/screen.css"}}" />
 
     {{ghost_head}}
 </head>


### PR DESCRIPTION
Missing opening quote for asset was causing the any page to 500, unable to parse handlebars.
